### PR TITLE
makefile: minor fix

### DIFF
--- a/inst/tests/test-cdb.r
+++ b/inst/tests/test-cdb.r
@@ -118,4 +118,4 @@ test_that("put docs", {
 db$read_only <- F
 
 # CLEAN UP
-system(sprintf("rm -r %s", path))
+unlink(path, recursive = T)

--- a/makefile
+++ b/makefile
@@ -15,5 +15,5 @@ check: build
 	cd ..;\
 	R CMD check $(PKGNAME)_$(PKGVERS).tar.gz --as-cran
 
-test:
+test: install
 	Rscript -e 'library(Coldbir);library(testthat);test_package("Coldbir")'


### PR DESCRIPTION
Minor fix so that it build and install the package when running `make test`. This makes sure that one is testing the latest version of the package.
