### PR TITLE
[#67] New message system

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,6 @@ License: AGPL-3
 Depends:
     data.table (>= 1.8.8),
     RJSONIO (>= 1.0-3),
-    futile.logger (>= 1.3.4),
     stringr (>= 0.6.2),
     lubridate (>= 1.3.0),
     yaml (>= 2.1.7),
@@ -30,3 +29,4 @@ Collate:
     'search-files.r'
     'list-variables.r'
     'utils.r'
+    'messages.r'

--- a/R/messages.r
+++ b/R/messages.r
@@ -1,5 +1,24 @@
-msg <- wrn <- err <- function(n, ...) {
+#' Log messages
+#' 
+#' Handlers for showing messages, warnings and errors.
+#' These functions are useful as many of the log messages
+#' are re-used in the code. `msg()` is used for ordinary messages,
+#' `wrn()` for warnings and `err()` for throwing an error and
+#' interrupting the code from further evaulation.
+#' 
+#' @param n message code. The number used must exist in table available in the code.
+#' @param ... arguments passed on to `sprintf()`.
+#' 
+#' @examples 
+#' \dontrun{
+#' msg(3, "foo")
+#' }
+#' 
+#' @rdname messages
+msg <- function(n, ...) {
   
+  # Message codes are available in the table below;
+  # some numbers in between have been removed since they aren't used anymore.
   str <- sprintf(switch(
     as.character(n),  # obs: convert to char since int otherwise refers to index
     "0"   = "Error message is not defined!",
@@ -7,17 +26,13 @@ msg <- wrn <- err <- function(n, ...) {
     "2"   = "%s - writing failed; rollback! (%s)",
     "3"   = "%s - no such data base",
     "4"   = "%s : %s - no documantation for this variable",
-  # "5"   = "File path: %s",
     "6"   = "%s - file does not exist",
     "7"   = "%s - version of coldbir package and file format does not match",
     "8"   = "You're only allowed to read data, to change this use db$read_only <- F",
     "9"   = "%s - variable is NULL; nothing to write",
-  # "10"  = "%s - all values are missing",
     "11"  = "%s - length of variable doesn't match the size of the other columns; nothing will be written",
-  # "12"  = "%s - character converted to factor",
     "13"  = "%s - data type is not supported",
     "14"  = "%s - writing failed; rollback! (%s)",
-  # "15"  = "Success: %s",
     "16"  = "input must be a two-column data frame"
   ), ...)
   
@@ -30,3 +45,9 @@ msg <- wrn <- err <- function(n, ...) {
     "err" = stop(str)
   )
 }
+
+#' @rdname messages
+wrn <- msg
+
+#' @rdname messages
+err <- msg

--- a/R/messages.r
+++ b/R/messages.r
@@ -9,7 +9,7 @@
 #' @param n message code. The number used must exist in table available in the code.
 #' @param ... arguments passed on to `sprintf()`.
 #' 
-#' @examples 
+#' @examples
 #' \dontrun{
 #' msg(3, "foo")
 #' }

--- a/R/messages.r
+++ b/R/messages.r
@@ -1,0 +1,32 @@
+msg <- wrn <- err <- function(n, ...) {
+  
+  str <- sprintf(switch(
+    as.character(n),  # obs: convert to char since int otherwise refers to index
+    "0"   = "Error message is not defined!",
+    "1"   = "Config file updated, although `db$read_only` is set to TRUE",
+    "2"   = "%s - writing failed; rollback! (%s)",
+    "3"   = "%s - no such data base",
+    "4"   = "%s : %s - no documantation for this variable",
+  # "5"   = "File path: %s",
+    "6"   = "%s - file does not exist",
+    "7"   = "%s - version of coldbir package and file format does not match",
+    "8"   = "You're only allowed to read data, to change this use db$read_only <- F",
+    "9"   = "%s - variable is NULL; nothing to write",
+  # "10"  = "%s - all values are missing",
+    "11"  = "%s - length of variable doesn't match the size of the other columns; nothing will be written",
+  # "12"  = "%s - character converted to factor",
+    "13"  = "%s - data type is not supported",
+    "14"  = "%s - writing failed; rollback! (%s)",
+  # "15"  = "Success: %s",
+    "16"  = "input must be a two-column data frame"
+  ), ...)
+  
+  if (is.null(str)) err(0)
+  
+  switch(
+    as.character(match.call()[[1]]),  # name of calling function
+    "msg" = message(str),
+    "wrn" = warning(str),
+    "err" = stop(str)
+  )
+}

--- a/inst/tests/test-cdb.r
+++ b/inst/tests/test-cdb.r
@@ -1,6 +1,6 @@
 path <- tempfile()
 size <- 1e3
-db <- cdb(path, log_level = 1, read_only = F)
+db <- cdb(path, read_only = F)
 
 context("INITIALIZE DATABASE")
 ##############################

--- a/man/cdb.Rd
+++ b/man/cdb.Rd
@@ -8,18 +8,18 @@
   \item{path}{Database path (the location of the coldbir
   database)}
 
-  \item{log_level}{Log level (default: 4). Available
-  levels: 1-9.}
-
-  \item{log_file}{Log file. As default log messages will be
-  written to console.}
-
   \item{compress}{file compression level}
 
   \item{encoding}{set documentation encoding (default:
   UTF-8)}
 
   \item{read_only}{read only (default: T)}
+
+  \item{db_version}{instance-attribute for sycronisation of
+  current list of variables}
+
+  \item{n_row}{the common length of vecrors in the
+  database}
 }
 \description{
   Method to assign either a new or existing coldbir

--- a/man/messages.Rd
+++ b/man/messages.Rd
@@ -1,0 +1,32 @@
+\name{msg}
+\alias{err}
+\alias{msg}
+\alias{wrn}
+\title{Log messages}
+\usage{
+  msg(n, ...)
+
+  wrn(n, ...)
+
+  err(n, ...)
+}
+\arguments{
+  \item{n}{message code. The number used must exist in
+  table available in the code.}
+
+  \item{...}{arguments passed on to `sprintf()`.}
+}
+\description{
+  Handlers for showing messages, warnings and errors. These
+  functions are useful as many of the log messages are
+  re-used in the code. `msg()` is used for ordinary
+  messages, `wrn()` for warnings and `err()` for throwing
+  an error and interrupting the code from further
+  evaulation.
+}
+\examples{
+\dontrun{
+msg(3, "foo")
+}
+}
+


### PR DESCRIPTION
Removed `futile.logger` from the package and implemented another solution for messages, warnings and errors. See `R/messages.r`.

Todo:
- [x] add roxygen documentation
- ~~add option to show/hide messages and warnings, e.g. `cdb(..., verbose = T)`. Default: `verbose = F`. However, it seems a bit unnecessary to pass the `verbose` argument in each `msg, err, wrn` call, and the messages doesn't really belong to the `cdb` class itself. Might save this for a later release, as it is not obvious how to solve it.~~
